### PR TITLE
Fds accessor

### DIFF
--- a/pstream.h
+++ b/pstream.h
@@ -168,6 +168,10 @@ namespace redi
       fopen(FILE*& in, FILE*& out, FILE*& err);
 #endif
 
+      /// Obtain file descriptors for each of the process' standards streams.
+      std::size_t
+      fds(fd_type& in, fd_type& out, fd_type& err);
+
       /// Return the exit status of the process.
       int
       status() const;
@@ -358,6 +362,10 @@ namespace redi
       std::size_t
       fopen(FILE*& in, FILE*& out, FILE*& err);
 #endif
+
+      /// Obtain file descriptors for each of the process' standards streams.
+      std::size_t
+      fds(fd_type& in, fd_type& out, fd_type& err);
 
     protected:
       std::string       command_; ///< The command used to start the process.
@@ -2440,6 +2448,63 @@ namespace redi
 
 #endif // REDI_EVISCERATE_PSTREAMS
 
+  /**
+   * @warning  This function exposes the internals of the stream buffer and
+   *           should be used with caution. It is the caller's responsibility
+   *           to manage any interactions between iostream and raw I/O on the
+   *           file descriptors.
+   *
+   * @param   in    An integer that will be the process' stdin.
+   * @param   out   An integer that will be the process' stdout.
+   * @param   err   An integer that will be the process' stderr.
+   * @return  An OR of zero or more of @c pstdin, @c pstdout, @c pstderr.
+   *
+   * For each open stream shared with the child process the file descriptor
+   * used is assigned to the corresponding parameter. For closed
+   * streams @c -1 is assigned to the parameter.
+   * The return value can be tested to see which parameters are valid
+   * by masking with the corresponding @c pmode value.
+   */
+  template <typename C, typename T>
+    std::size_t
+    basic_pstreambuf<C,T>::fds(fd_type& in, fd_type& out, fd_type& err)
+    {
+      in = out = err = -1;
+      std::size_t open_files = 0;
+      if (wpipe() > -1)
+      {
+        in = wpipe();
+        open_files |= pstdin;
+      }
+      if (rpipe(rsrc_out) > -1)
+      {
+        out = rpipe(rsrc_out);
+        open_files |= pstdout;
+      }
+      if (rpipe(rsrc_err) > -1)
+      {
+        err = rpipe(rsrc_err);
+        open_files |= pstderr;
+      }
+      return open_files;
+    }
+
+  /**
+   *  @warning This function exposes the internals of the stream buffer and
+   *  should be used with caution.
+   *
+   *  @param  in   An integer that will refer to the process' stdin.
+   *  @param  out  An integer that will refer to the process' stdout.
+   *  @param  err  An integer that will refer to the process' stderr.
+   *  @return A bitwise-or of zero or more of @c pstdin, @c pstdout, @c pstderr.
+   *  @see    basic_pstreambuf::fds()
+   */
+  template <typename C, typename T>
+    inline std::size_t
+    pstream_common<C,T>::fds(fd_type& fin, fd_type& fout, fd_type& ferr)
+    {
+      return buf_.fds(fin, fout, ferr);
+    }
 
 } // namespace redi
 

--- a/test_pstreams.cc
+++ b/test_pstreams.cc
@@ -705,10 +705,12 @@ int main()
 
         const size_t len = 256;
         char buf[len];
+        buf[0] = '\0';
         char* p = fgets(buf, len, out);
         cout << "STDOUT: " << buf;
         print_result(is, p!=NULL);
 
+        buf[0] = '\0';
         p = fgets(buf, len, err);
         cout << "STDERR: " << buf;
         print_result(is, p!=NULL);
@@ -730,10 +732,12 @@ int main()
 #if 0
         size_t len = 256;
         char buf[len];
+        buf[0] = '\0';
         char* p = fgets(buf, len, out);
         cout << "STDOUT: " << buf;
         print_result(ps, p!=NULL);
 
+        buf[0] = '\0';
         p = fgets(buf, len, err);
         cout << "STDERR: " << buf;
         print_result(ps, p!=NULL);


### PR DESCRIPTION
We're using pstreams in a threaded program and running into problems that can be solved with `FD_CLOEXEC`.  We can get at the `FILE*`s with `fopen()` and then the file descriptors with `fileno(FILE*)`.  But this invokes unnecessary action, and our platform doesn't have an `fdclose()` call to clean up.

So I wrote a `fds()` accessor that returns the existing file descriptors, rather than new stdio files.  This arguably is a better way to provide access to the underlying pipes, because it is easy to call `fdopen()` on these file descriptors.

Would you consider this?  I left the code outside `REDI_EVISCERATE_PSTREAMS` because the interaction with raw I/O is simpler, and setsockopt/ioctl are valid, non-hacky reasons to access the file descriptors, but that is really your call.  There's a couple of other small fixes as well.  Tested on Ubuntu 17.04, OS X/Xcode 10.13, FreeBSD 11.1.

I've submitted this here because I don't have an SF account handy and GH is superior for submitting multiple commits, but I can submit on SF if that's better for you.
