### PR TITLE
(pbsz,bufsz): Use constants instead of enums

### DIFF
--- a/pstream.h
+++ b/pstream.h
@@ -81,8 +81,8 @@ namespace redi
     static const pmode newpg   = std::ios_base::trunc;
 
   protected:
-    enum { bufsz = 32 };  ///< Size of pstreambuf buffers.
-    enum { pbsz  = 2 };   ///< Number of putback characters kept.
+    static const std::size_t bufsz = 32; ///< Size of pstreambuf buffers.
+    static const std::size_t pbsz  = 2;  ///< Number of putback characters kept.
 
 #if __cplusplus >= 201103L
     template<typename T>


### PR DESCRIPTION
This reverts commit 3c24220b74ae1f88ff96b7b8588b43918d9f6a44. Today's
compilers are probably more than able to avoid emitting constants if
they're not required. On the other hand, latest GCC emits warnings when
values from different enumerations are compared.